### PR TITLE
Add default for tag lookup in job queue resources.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -226,7 +226,7 @@ resource "aws_batch_job_queue" "this" {
   scheduling_policy_arn = try(each.value.scheduling_policy_arn, aws_batch_scheduling_policy.this[each.key].arn)
   compute_environments  = [for env in aws_batch_compute_environment.this : env.arn]
 
-  tags = merge(var.tags, lookup(each.value, "tags"))
+  tags = merge(var.tags, lookup(each.value, "tags", {}))
 }
 
 ################################################################################
@@ -251,7 +251,7 @@ resource "aws_batch_scheduling_policy" "this" {
     }
   }
 
-  tags = merge(var.tags, lookup(each.value, "tags"))
+  tags = merge(var.tags, lookup(each.value, "tags", {}))
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
The job queue and scheduling policy resources are missing the default values for the `lookup` function.

## Motivation and Context
Without this change, you need to add tags specific to each job queue.

## Breaking Changes
No

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
