### PR TITLE
feat: Add create_scheduling_policy option to job_queue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,7 +223,7 @@ resource "aws_batch_job_queue" "this" {
   name                  = each.value.name
   state                 = each.value.state
   priority              = each.value.priority
-  scheduling_policy_arn = try(each.value.scheduling_policy_arn, aws_batch_scheduling_policy.this[each.key].arn)
+  scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
   compute_environments  = [for env in aws_batch_compute_environment.this : env.arn]
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
@@ -234,7 +234,7 @@ resource "aws_batch_job_queue" "this" {
 ################################################################################
 
 resource "aws_batch_scheduling_policy" "this" {
-  for_each = { for k, v in var.job_queues : k => v if var.create && var.create_job_queues }
+  for_each = { for k, v in var.job_queues : k => v if var.create && var.create_job_queues && try(v.create_scheduling_policy, true) }
 
   name = each.value.name
 


### PR DESCRIPTION
With this, someone can use attach_scheduling_policy in their job_queue definition to skip over scheduling policy attachment.

## Description
Right now, a scheduling policy is auto-attached to all job queues. Adding "attach_scheduling_policy" when defining people's job queues will override the default behaviour.

## Motivation and Context
I don't want to always have a scheduling policy for my queues.

## Breaking Changes
No, it uses lookup, and defaults to the original behaviour

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
