### PR TITLE
chore: Correct resourceRequirements in Fargate example

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -129,8 +129,8 @@ module "batch" {
           platformVersion = "LATEST"
         },
         resourceRequirements = [
-          { type = "VCPU", value = 1 },
-          { type = "MEMORY", value = 1024 }
+          { type = "VCPU", value = "1" },
+          { type = "MEMORY", value = "2048" }
         ],
         executionRoleArn = aws_iam_role.ecs_task_execution_role.arn
         logConfiguration = {


### PR DESCRIPTION
It fixes 2 bugs:

> Error: AWS Batch Job container_properties is invalid: Error decoding JSON: json: cannot unmarshal number into Go struct field ResourceRequirement.ResourceRequirements.Value of type string

and

> Error: error creating Batch Job Definition (batch-ex-fargate): : Error executing request, Exception : Fargate resource requirements (1.00 vCPU, 1024 MiB) not valid.,

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
