### PR TITLE
docs: Document job queue without schedule priority example

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -114,6 +114,17 @@ module "batch" {
         JobQueue = "High priority job queue"
       }
     }
+
+    no_scheduling_policy_priority = {
+	create_scheduling_policy = false
+        name     = "noOptioinalSchedulingPolicyPriorityFargate"
+        state    = "ENABLED"
+        priority = 1
+
+        tags = {
+          JobQueue = "No optional scheduling priority job queue"
+        }
+    }
   }
 
   job_definitions = {


### PR DESCRIPTION
## Description

Show example of using `create_scheduling_policy`

## Motivation and Context

By default it creates a scheduling policy without specifying any, it is optional, supported in this TF but no doc for it.

## Breaking Changes

No, just an example. 

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Terraform plan went through upon additional.