### PR TITLE
feat: Allow specifying compute environments for queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ module "batch" {
       state    = "ENABLED"
       priority = 1
 
+      compute_environments = ["b_ec2_spot"]
+
       tags = {
         JobQueue = "Low priority job queue"
       }
@@ -92,8 +94,6 @@ module "batch" {
           weight_factor    = 0.2
         }]
       }
-
-      compute_environments = ["b_ec2_spot"]
       
       tags = {
         JobQueue = "High priority job queue"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ module "batch" {
         }]
       }
 
+      compute_environments = ["b_ec2_spot"]
+      
       tags = {
         JobQueue = "High priority job queue"
       }

--- a/examples/ec2/main.tf
+++ b/examples/ec2/main.tf
@@ -144,6 +144,8 @@ module "batch" {
       state    = "ENABLED"
       priority = 1
 
+      compute_environments = ["b_ec2_spot"]
+
       tags = {
         JobQueue = "Low priority job queue"
       }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn], 0, 2)
+  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3))
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  compute_environments  = [for env in aws_batch_compute_environment.this : env.arn]
+  compute_environments  = [for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn]
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  compute_environments  = [for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn]
+  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn], 0, 2)
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)): aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3))
+  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)) : aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3))
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }


### PR DESCRIPTION
## Description
Allow specifying compute environments for a job queue, and fix an issue when there are more than 3 compute environments.

## Motivation and Context
Job queue should have maximum 3 compute environments associated with it. 
Current version attaches ALL compute environments to all job queues, which is an issue because if more than 3 compute environments are defined - the apply will fail.
In addition, the module do not allow specifying compute environment(s) to be used by a specific queue.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
