### PR TITLE
fix: Add `create_before_destroy` lifecycle hook to `aws_batch_compute_environment`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_batch_compute_environment" "this" {
   # Prevent a race condition during environment deletion, otherwise the policy may be destroyed
   # too soon and the compute environment will then get stuck in the `DELETING` state
   depends_on = [aws_iam_role_policy_attachment.service]
-    
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,10 @@ resource "aws_batch_compute_environment" "this" {
   # Prevent a race condition during environment deletion, otherwise the policy may be destroyed
   # too soon and the compute environment will then get stuck in the `DELETING` state
   depends_on = [aws_iam_role_policy_attachment.service]
+    
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }


### PR DESCRIPTION
## Description

Solves https://github.com/terraform-aws-modules/terraform-aws-batch/issues/5. Also discussed in this stackoverflow question: 
https://stackoverflow.com/questions/61669156/terraform-how-to-enable-deletion-of-batch-service-compute-environment

## Motivation and Context
After applying and then making changes to the terraform, I am met with this error:
```

Error: deleting Batch Compute Environment (ec2_spot-20230302161118607200000001): : Cannot delete, found existing JobQueue relationship.
 	status code: 400, request id: d1174a9c-525b-45d5-8b4e-6830ea7a7246
```

No jobs are in the queue. This error is due to a dependency issue and is solved with this lifecycle hook. 
To quote the stackoverflow answer:

> When a resource is recreated in Terraform, it will be deleted and created in order by default. So if compute_environment_nameyou change and apply only, the computing environment on which the job queue depends temporarily does not exist, so you will die as follows. Error: Error applying plan:[...]
Therefore, compute_environment_namechange create_before_destroy = trueand specify the lifecycle explicitly.


## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
