### PR TITLE
fix: Change `instance_iam_role_use_name_prefix` to use correct data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ No modules.
 | <a name="input_service_iam_role_path"></a> [service\_iam\_role\_path](#input\_service\_iam\_role\_path) | Batch service IAM role path | `string` | `null` | no |
 | <a name="input_service_iam_role_permissions_boundary"></a> [service\_iam\_role\_permissions\_boundary](#input\_service\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_service_iam_role_tags"></a> [service\_iam\_role\_tags](#input\_service\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
-| <a name="input_service_iam_role_use_name_prefix"></a> [service\_iam\_role\_use\_name\_prefix](#input\_service\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`service_iam_role_name`) is used as a prefix | `string` | `true` | no |
+| <a name="input_service_iam_role_use_name_prefix"></a> [service\_iam\_role\_use\_name\_prefix](#input\_service\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`service_iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_spot_fleet_iam_role_additional_policies"></a> [spot\_fleet\_iam\_role\_additional\_policies](#input\_spot\_fleet\_iam\_role\_additional\_policies) | Additional policies to be added to the IAM role | `list(string)` | `[]` | no |
 | <a name="input_spot_fleet_iam_role_description"></a> [spot\_fleet\_iam\_role\_description](#input\_spot\_fleet\_iam\_role\_description) | Spot fleet IAM role description | `string` | `null` | no |
 | <a name="input_spot_fleet_iam_role_name"></a> [spot\_fleet\_iam\_role\_name](#input\_spot\_fleet\_iam\_role\_name) | Spot fleet IAM role name | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -90,7 +90,7 @@ variable "service_iam_role_name" {
 
 variable "service_iam_role_use_name_prefix" {
   description = "Determines whether the IAM role name (`service_iam_role_name`) is used as a prefix"
-  type        = string
+  type        = bool
   default     = true
 }
 


### PR DESCRIPTION
## Description
changes data type of variable "instance_iam_role_use_name_prefix" to bool

## Motivation and Context
Is to align the correct data type, the result in putting in a string

```bash
Error: Incorrect condition type
│
│   on .terraform/modules/pull.batch/main.tf line 88, in resource "aws_iam_role" "instance":
│   88:   name        = var.instance_iam_role_use_name_prefix ? null : var.instance_iam_role_name
│     ├────────────────
│     │ var.instance_iam_role_use_name_prefix is "runner"
│
│ The condition expression must be of type bool.
```


## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided examples/* projects
  I use this module in my workflow and just tested it locally
- [x] I have executed pre-commit run -a on my pull request
```
Terraform fmt............................................................Passed
Terraform validate.......................................................Passed
Terraform docs...........................................................Passed
Terraform validate with tflint...........................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```