### PR TITLE
fix: Rename launch template parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,8 @@ resource "aws_batch_compute_environment" "this" {
       dynamic "launch_template" {
         for_each = !contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) && try(compute_resources.value.launch_template, null) != null ? [compute_resources.value.launch_template] : []
         content {
-          launch_template_id   = lookup(launch_template.value, "id", null)
-          launch_template_name = lookup(launch_template.value, "name", null)
+          launch_template_id   = lookup(launch_template.value, "id", lookup(launch_template.value, "launch_template_id", null))
+          launch_template_name = lookup(launch_template.value, "name", lookup(launch_template.value, "launch_template_name", null))
           version              = lookup(launch_template.value, "version", null)
         }
       }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* A user can set their launch_template_id parameter by using `id` or `launch_template_id`. 
* A user can set their launch_template_name parameter by using `name` or `launch_template_name`. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Renaming these parameters to align with the `aws_batch_compute_environment` resource found [here](
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_compute_environment#launch_template_id). 
* Using the `id` and `name` parameters is a little confusing as it is not consistent with the `aws_batch_compute_environment` resource. 
* Other parameters in this module use the same naming convention as the `aws_batch_compute_environment` resource.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This change is backwards compatible.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
