### PR TITLE
fix: Job definition is always recreated when attempt_duration_seconds is null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -287,8 +287,11 @@ resource "aws_batch_job_definition" "this" {
     }
   }
 
-  timeout {
-    attempt_duration_seconds = lookup(each.value, "attempt_duration_seconds", null)
+  dynamic "timeout" {
+    for_each = lookup(each.value, "attempt_duration_seconds", null) != null ? [each.value.attempt_duration_seconds] : []
+    content {
+      attempt_duration_seconds = timeout.value
+    }
   }
 
   propagate_tags = lookup(each.value, "propagate_tags", null)


### PR DESCRIPTION
## Description

When a job definition in the module parameter `job_definitions` has not set `attempt_duration_seconds` it always shows a drift between what terraform has set and what AWS returns.

## Motivation and Context
The job definition is not recreated after this change.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
