### PR TITLE
feat: Parameter compute_environments set to deprecation by aws provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,13 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)) : aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3))
+  dynamic "compute_environment_order" {
+    for_each = { for index, elem in slice([for env in try(each.value.compute_environments, keys(var.compute_environments)) : aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3)) : elem => { order = index + 1, compute_environment = elem } }
+    content {
+      order               = compute_environment_order.value.order
+      compute_environment = compute_environment_order.value.compute_environment
+    }
+  }
 
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }


### PR DESCRIPTION
## Description
Small change, compute_environments in favor of new computer_environment_order.

## Motivation and Context
compute_environments will be deprecated anytime in the future https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_job_queue#compute_environments

## Breaking Changes
It was tested, and the only change will reside if user wants to run a terraform import.

## How Has This Been Tested?
Internal testing performed, and also tested with terragrunt.
![image](https://github.com/terraform-aws-modules/terraform-aws-batch/assets/207562/d04ddd73-0f76-4987-9c21-7909b2c6b100)
