### PR TITLE
Add eks_configuration to compute_environment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,14 @@ resource "aws_batch_compute_environment" "this" {
     }
   }
 
+  dynamic "eks_configuration" {
+    for_each = lookup(each.value, "eks_configuration", null) != null ? [each.value.eks_configuration] : []
+    content {
+      eks_cluster_arn = eks_configuration.value.eks_cluster_arn
+      kubernetes_namespace = eks_configuration.value.kubernetes_namespace
+    }
+  }
+
   # Prevent a race condition during environment deletion, otherwise the policy may be destroyed
   # too soon and the compute environment will then get stuck in the `DELETING` state
   depends_on = [aws_iam_role_policy_attachment.service]


### PR DESCRIPTION
## Description
Add support for `eks_configuration` in `compute_environment`

## Motivation and Context
EKS EC2 environments require additional configuration in order to work properly. The provider specifies this configuration but it wasn't present in the module.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
