### PR TITLE
feat: Add support for aws_batch_job_queue.job_state_time_limit_action

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -239,6 +239,16 @@ resource "aws_batch_job_queue" "this" {
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
   compute_environments  = slice([for env in try(each.value.compute_environments, keys(var.compute_environments)) : aws_batch_compute_environment.this[env].arn], 0, min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3))
 
+  dynamic "job_state_time_limit_action" {
+    for_each = try(each.value.job_state_time_limit_actions, {})
+    content {
+      action           = job_state_time_limit_action.value.action
+      max_time_seconds = job_state_time_limit_action.value.max_time_seconds
+      reason           = job_state_time_limit_action.value.reason
+      state            = job_state_time_limit_action.value.state
+    }
+  }
+
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }
 


### PR DESCRIPTION
## Description

Add support for specifying job_state_time_limit_action for aws_batch_job_queue, cf. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_job_queue#job_state_time_limit_action

## Motivation and Context

Feature.

## Breaking Changes

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request