### PR TITLE
fix: Rename deprecated variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -237,24 +237,24 @@ resource "aws_batch_job_queue" "this" {
   state                 = each.value.state
   priority              = each.value.priority
   scheduling_policy_arn = try(each.value.create_scheduling_policy, true) ? aws_batch_scheduling_policy.this[each.key].arn : try(each.value.scheduling_policy_arn, null)
-  
-  dynamic "compute_environment_order" {
-      for_each = [
-        for idx, env in slice(
-          try(each.value.compute_environments, keys(var.compute_environments)),
-          0,
-          min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3)
-        ) : {
-          order = idx + 1
-          arn   = aws_batch_compute_environment.this[env].arn
-        }
-      ]
 
-      content {
-        order               = compute_environment_order.value.order
-        compute_environment = compute_environment_order.value.arn
+  dynamic "compute_environment_order" {
+    for_each = [
+      for idx, env in slice(
+        try(each.value.compute_environments, keys(var.compute_environments)),
+        0,
+        min(length(try(each.value.compute_environments, keys(var.compute_environments))), 3)
+        ) : {
+        order = idx + 1
+        arn   = aws_batch_compute_environment.this[env].arn
       }
+    ]
+
+    content {
+      order               = compute_environment_order.value.order
+      compute_environment = compute_environment_order.value.arn
     }
+  }
   tags = merge(var.tags, lookup(each.value, "tags", {}))
 }
 


### PR DESCRIPTION
## Description

Updated `aws_batch_job_queue` resource to use the new `compute_environment_order` block format introduced in newer versions of the AWS provider. This replaces the deprecated `compute_environments` list attribute. Additionally, aligned naming attributes in `aws_batch_compute_environment` to the latest supported `name` and `name_prefix` syntax from AWS provider >= 6.0.

## Motivation and Context

This change is required to maintain compatibility with recent versions of the AWS provider 6.0, which deprecated the `compute_environments` attribute in `aws_batch_job_queue` in favor of explicit `compute_environment_order` blocks. Also addresses the renaming of `compute_environment_name` to `name` and `compute_environment_name_prefix` to `name_prefix` in `aws_batch_compute_environment`.

Reference: [AWS Provider v6.0.0 Changelog](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#600-may-23-2024)

## Breaking Changes

No breaking changes.

## How Has This Been Tested?

- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided examples/* projects
- [] I have executed `pre-commit run -a` on my pull request
