### PR TITLE
fix: Remove erroneous `pod_properties` scoping from job definition variable attribute structure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -452,11 +452,11 @@ resource "aws_batch_job_definition" "this" {
           }
         }
 
-        dns_policy   = eks_properties.value.pod_properties.dns_policy
-        host_network = eks_properties.value.pod_properties.host_network
+        dns_policy   = eks_properties.value.dns_policy
+        host_network = eks_properties.value.host_network
 
         dynamic "image_pull_secret" {
-          for_each = eks_properties.value.pod_properties.image_pull_secrets != null ? eks_properties.value.pod_properties.image_pull_secrets : []
+          for_each = eks_properties.value.image_pull_secrets != null ? eks_properties.value.image_pull_secrets : []
 
           content {
             name = image_pull_secret.value.name
@@ -464,7 +464,7 @@ resource "aws_batch_job_definition" "this" {
         }
 
         dynamic "init_containers" {
-          for_each = eks_properties.value.pod_properties.init_containers != null ? eks_properties.value.pod_properties.init_containers : {}
+          for_each = eks_properties.value.init_containers != null ? eks_properties.value.init_containers : {}
 
           content {
             args    = init_containers.value.args
@@ -517,18 +517,18 @@ resource "aws_batch_job_definition" "this" {
         }
 
         dynamic "metadata" {
-          for_each = eks_properties.value.pod_properties.metadata != null ? [eks_properties.value.pod_properties.metadata] : []
+          for_each = eks_properties.value.metadata != null ? [eks_properties.value.metadata] : []
 
           content {
             labels = metadata.value.labels
           }
         }
 
-        service_account_name    = eks_properties.value.pod_properties.service_account_name
-        share_process_namespace = eks_properties.value.pod_properties.share_process_namespace
+        service_account_name    = eks_properties.value.service_account_name
+        share_process_namespace = eks_properties.value.share_process_namespace
 
         dynamic "volumes" {
-          for_each = eks_properties.value.pod_properties.volumes != null ? eks_properties.value.pod_properties.volumes : {}
+          for_each = eks_properties.value.volumes != null ? eks_properties.value.volumes : {}
 
           content {
             dynamic "empty_dir" {


### PR DESCRIPTION
## Description
This PR fixes the way EKS pod properties are referenced in the aws_batch_job_definition resource in main.tf.
The module previously accessed attributes like dns_policy, host_network, image_pull_secrets, etc. from eks_properties.value.pod_properties, but according to the variable definition, these should be accessed directly from eks_properties.value.

## Motivation and Context
- Resolves #44 

This change is required to align the module implementation with the variable structure defined in variables.tf.
It solves errors like:
```
│ Error: Unsupported attribute
│   on .../main.tf line 455, in resource "aws_batch_job_definition" "this":
│  455:         dns_policy   = eks_properties.value.pod_properties.dns_policy
│     ├────────────────
│     │ eks_properties.value.pod_properties is object with 1 attribute "containers"
│ 
│ This object does not have an attribute named "dns_policy".
```
and similar errors for other attributes.

## Breaking Changes
No breaking changes. This PR only corrects attribute references to match the documented variable structure.

## How Has This Been Tested?
Used a minimal EKS job definition with pod properties and confirmed that the job definition is created successfully.
Verified that the AWS Console displays the "Pod Properties" tab and all configured properties.
