### PR TITLE
fix: Ensure a list of attributes can be used on `ec2_configuration`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_batch_compute_environment" "this" {
       desired_vcpus       = contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) ? null : compute_resources.value.desired_vcpus
 
       dynamic "ec2_configuration" {
-        for_each = !contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) && compute_resources.value.ec2_configuration != null ? [compute_resources.value.ec2_configuration] : []
+        for_each = !contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) && compute_resources.value.ec2_configuration != null ? compute_resources.value.ec2_configuration : []
 
         content {
           image_id_override = ec2_configuration.value.image_id_override


### PR DESCRIPTION
## Description
- Ensure a list of attributes can be used on `ec2_configuration`

https://github.com/hashicorp/terraform-provider-aws/blob/229b588b9676522d110ebdf0accffa821aef6b51/internal/service/batch/compute_environment.go#L109

## Motivation and Context
- Resolves #46

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
