### PR TITLE
fix: Correct attribute name for external spot IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "aws_batch_compute_environment" "this" {
       min_vcpus           = contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) ? null : compute_resources.value.min_vcpus
       placement_group     = compute_resources.value.placement_group
       security_group_ids  = compute_resources.value.security_group_ids
-      spot_iam_fleet_role = compute_resources.value.type == "SPOT" ? try(aws_iam_role.spot_fleet[0].arn, compute_resources.value.spot_fleet_role) : null
+      spot_iam_fleet_role = compute_resources.value.type == "SPOT" ? try(aws_iam_role.spot_fleet[0].arn, compute_resources.value.spot_iam_fleet_role) : null
       subnets             = compute_resources.value.subnets
       # We do not merge with default `var.tags` here because tag changes cause compute environment replacement
       tags = contains(["FARGATE", "FARGATE_SPOT"], compute_resources.value.type) ? null : compute_resources.value.tags


### PR DESCRIPTION
## Description
On line 57 of main.tf, changed the second argument of the try in the dynamic 'compute_resources' to lookup 'spot_iam_fleet_role' instead of the incorrect 'spot_fleet_role'.

## Motivation and Context
When using the compute resources type 'SPOT' and passing an external ARN for spot_iam_fleet_role, the try fails on the first argument of the tuple (checks count for internal creation of spot_iam_fleet_role), then attempts the second argument which looks for the value 'spot_fleet_role' to be passed by user -> 'compute_resources.value.spot_fleet_role'. 

This is likely a typo for 'spot_iam_fleet_role', because 'spot_fleet_role' doesn't exist in variables.tf so it would fail if it tried to be defined in the usage main.tf.

If you try to pass an external ARN by defining spot_iam_fleet_role, the code errors on terraform plan because the second argument of the tuple can only define 'spot_fleet_role' (the typo), resulting in an empty tuple.

The only way to currently create a 'compute_resources' block with type 'SPOT' is to have the module create its own spot_iam_fleet_role i.e 'create_spot_fleet_iam_role' must  = 'true'.

TLDR: either 'spot_fleet_role' has to be added to variables.tf so it can be passed into the tuple, or the tuple has to define 'spot_iam_fleet_role' in the second argument. Since 'spot_iam_fleet_role' was already in variables.tf I assumed this was the intent and implemented the latter.

## How Has This Been Tested?
Duplicated the example ec2 dir (not present in commit for minimalism) and modified values to recreate the bug, here are the changes required:

In line 51 you must set have the module not create its own role
 ```hcl
  create_spot_fleet_iam_role      = false ### <- doesn't create its own role
  spot_fleet_iam_role_name        = "${local.name}-spot"
  spot_fleet_iam_role_path        = "/batch/"
  spot_fleet_iam_role_description = "IAM spot fleet role for AWS Batch"
  spot_fleet_iam_role_tags = {
    ModuleCreatedRole = "Yes"
  }
```
After line 97 you must attempt to pass an external ARN for spot_iam_fleet_role

```hcl
    b_ec2_spot = {
... some variables being defined...

        security_group_ids = [module.vpc_endpoints.security_group_id]
        spot_iam_fleet_role = "arn:aws:iam::123456789012:role/MyTestSpotRole" ### <- Must try to pass external ARN
        subnets            = module.vpc.private_subnets

        # Note - any tag changes here will force compute environment replacement
        # which can lead to job queue conflicts. Only specify tags that will be static
        # for the lifetime of the compute environment
        tags = {
          # This will set the name on the Ec2 instances launched by this compute environment
          Name = "${local.name}-spot"
          Type = "Ec2Spot"
        }
      }
    }
```
Then you can run terraform init and terraform plan and view the 'empty tuple error'. Once you make the fix i.e 
'compute_resources.value.spot_fleet_role' -> 'compute_resources.value.spot_iam_fleet_role'. Terraform plan will succeed. 

Notes: 
Version of code -> 3.0.3
Anything special about your env? -> nope, I assume most people either run an EC2 type (on demand) or have the module create its own role.
Other modifications -> nope, readme change is terraform docs running on pre-commit.
